### PR TITLE
simplify bundler handling

### DIFF
--- a/lib/mapbox-sdk.rb
+++ b/lib/mapbox-sdk.rb
@@ -1,0 +1,1 @@
+require 'mapbox'


### PR DESCRIPTION
* does not need `require: 'mapbox'` in Gemfile anymore
* still clashes `::Mapbox` namespace with "mapbox" gem (unofficial)

NBD