### PR TITLE
Add geocoding limit parameter

### DIFF
--- a/lib/mapbox/geocoder.rb
+++ b/lib/mapbox/geocoder.rb
@@ -10,8 +10,9 @@ module Mapbox
     def self.geocode_forward(query, options={}, dataset='mapbox.places')
       proximity = options[:proximity]
       bbox = options[:bbox]
+      limit = options[:limit]
       params = ''
-      opts = options.select { |key, value| key != :proximity && key != :bbox}
+      opts = options.select { |key, value| key != :proximity && key != :bbox && key != :limit}
       if opts.length > 0
         params += "#{params.length > 0 ? '&' : '?'}#{URI.encode_www_form(opts)}"
       end
@@ -25,6 +26,10 @@ module Mapbox
       if bbox then
         params += "#{params.length > 0 ? '&' : '?'}bbox=#{bbox.join('%2C')}"
       end
+
+      if limit then
+        params += "#{params.length > 0 ? '&' : '?'}limit=#{limit}"
+
       return request(
         :get,
         "/geocoding/v5/#{dataset}/#{URI.escape(query)}.json#{params}",

--- a/test/geocoding_test.rb
+++ b/test/geocoding_test.rb
@@ -39,6 +39,13 @@ module Mapbox
       assert Mapbox.request_opts[:url].include? '?country=ca';
     end
 
+    should "#geocode_forward (include limit param)" do
+      Mapbox.access_token = ENV["MapboxAccessToken"]
+      result = Mapbox::Geocoder.geocode_forward("Washington", {:limit => 3})
+      assert result
+      assert Mapbox.request_opts[:url].include? '?limit=3';
+    end
+
     should "#geocode_reverse" do
       Mapbox.access_token = ENV["MapboxAccessToken"]
       result = Mapbox::Geocoder.geocode_reverse({


### PR DESCRIPTION
Adds the limit parameter for geocoding calls per mapbox/api-geocoder#1102

I based this on the PR for adding bbox; please let me know if anything is missing.