### PR TITLE
Allow for selection of directions profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ placenames = Mapbox::Geocoder.geocode_reverse({
 # Forward geocoding with optional proximity parameter
 places = Mapbox::Geocoder.geocode_forward("Chester, NJ", {:proximity => {:longitude => -74.6968, :latitude => 40.7843}})
 
-# Directions
+# Driving directions with required profile parameter
 drivingDirections = Mapbox::Directions.directions([{
   "longitude" => -100,
   "latitude" => 38
 }, {
   "longitude" => -90,
   "latitude" => 38
-}])
+}], "driving")
+
+# In the above example, you can substitute `driving` for `driving-traffic`, `cycling` or `walking`. For more, [check out the documentation](https://www.mapbox.com/api-documentation/#directions).
 ```
 
 Heavily influenced by Stripe's Ruby client, and includes its MIT license.

--- a/lib/mapbox/directions.rb
+++ b/lib/mapbox/directions.rb
@@ -2,7 +2,7 @@ module Mapbox
   class Directions
     include Mapbox::APIOperations::Request
     extend Mapbox::HashUtils
-    def self.directions(waypoints, profile='driving')
+    def self.directions(waypoints, profile)
       formatted_waypoints = waypoints.map {|p| xy_from_hash(p).join ','}.join ';'
       return request(
           :get,

--- a/test/directions_test.rb
+++ b/test/directions_test.rb
@@ -16,7 +16,7 @@ module Mapbox
           :longitude => -90,
           :latitude => 38
         }
-      ])
+      ], "cycling")
       assert result
     end
   end


### PR DESCRIPTION
You can use [four different profiles](https://www.mapbox.com/api-documentation/#directions) with the Mapbox directions API - driving, driving-traffic, cycling, and walking. This PR opens up the ability to select the profile you wish to query.