### PR TITLE
WIP: Upgrade to Circle 2.0

### DIFF
--- a/.circleci/circle.yml
+++ b/.circleci/circle.yml
@@ -1,3 +1,4 @@
+version: 2
 machine:
     ruby:
         version: 2.3.0


### PR DESCRIPTION
Circle 1.0 is being deprecated as of August 31st, 2018.