### PR TITLE
update to restclient 2.0; fixes missing :cipher key error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('1.9.3')
   gem 'i18n', '< 0.7'
-  gem 'rest-client', '~> 1.6.8'
+  gem 'rest-client', '~> 2.0.1'
   gem 'activesupport', '~> 3.2'
   gem 'rake', '10.1.0'
 end

--- a/mapbox-sdk.gemspec
+++ b/mapbox-sdk.gemspec
@@ -10,7 +10,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://mapbox.com/developers'
   s.license = 'MIT'
 
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '~> 2.0.1')
 
   s.add_development_dependency('mocha', '~> 0.13.2')
   s.add_development_dependency('shoulda', '~> 3.4.0')


### PR DESCRIPTION
Greetings,

I was running into [this issue](https://github.com/rest-client/rest-client/issues/612) related to rest-client dependency. Updated to v2 and tests passed =) :clinking_glasses: 

edit: I noticed #17 is in the queue as well, please merge one of them!