### PR TITLE
Fix URI.encode obsolete warnings in Ruby 2.7

### DIFF
--- a/lib/mapbox.rb
+++ b/lib/mapbox.rb
@@ -33,7 +33,7 @@ module Mapbox
     case method.to_s.downcase.to_sym
     when :get, :head, :delete
       # Make params into GET parameters
-      url += "#{URI.parse(url).query ? '&' : '?'}#{uri_encode(params)}" if params && params.any?
+      url += "#{URI.parse(url).query ? '&' : '?'}#{URI.encode_www_form(params)}" if params && params.any?
       payload = nil
     end
 
@@ -70,15 +70,6 @@ module Mapbox
     end
 
     [parse(response), api_key]
-  end
-
-  def self.uri_encode(params)
-    params.
-      map { |k,v| "#{k}=#{url_encode(v)}" }.join('&')
-  end
-
-  def self.url_encode(key)
-    URI.escape(key.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
   end
 
   def self.execute_request(opts)

--- a/lib/mapbox/geocoder.rb
+++ b/lib/mapbox/geocoder.rb
@@ -39,7 +39,7 @@ module Mapbox
 
       return request(
         :get,
-        "/geocoding/v5/#{dataset}/#{URI.escape(query)}.json#{params}",
+        "/geocoding/v5/#{dataset}/#{URI.encode_www_form_component(query)}.json#{params}",
         nil)
     end
 


### PR DESCRIPTION
Since Ruby 2.7 URI.encode now throws warnings about being obsolete.
This PR replaces the uri_encode method with URI.encode_www_form which handles the same functionality.
