### PR TITLE
Update rest-client to 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('1.9.3')
   gem 'i18n', '< 0.7'
-  gem 'rest-client', '~> 2.0.1'
+  gem 'rest-client', '~> 2.1.0'
   gem "activesupport", ">= 4.1.11"
   gem 'rake', '10.1.0'
 end

--- a/mapbox-sdk.gemspec
+++ b/mapbox-sdk.gemspec
@@ -10,7 +10,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://mapbox.com/developers'
   s.license = 'MIT'
 
-  s.add_dependency('rest-client', '~> 2.0.1')
+  s.add_dependency('rest-client', '~> 2.1.0')
 
   s.add_development_dependency('mocha', '~> 0.13.2')
   s.add_development_dependency('shoulda', '~> 3.4.0')


### PR DESCRIPTION
Related to #50

Updating rest-client to it's latest version to avoid dependency conflicts with a lot of other libs locked with 2.1.0.